### PR TITLE
レイアウトの修正・Key情報の修正ボタンの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Title,
   LoadingOverlay,
   Textarea,
+  Center,
 } from "@mantine/core";
 
 const App: React.FC = () => {
@@ -81,40 +82,46 @@ const App: React.FC = () => {
     }
   };
 
-  const containerStyles = {
-    width: 120,
+  const handleResetKeys = () => {
+    setApiKey("");
+    setDatabaseId("");
+    setStep("setup");
   };
 
   if (step === "setup") {
     return (
-      <>
-        <Container>
-          <Title order={2}>Notion設定</Title>
+      <Container style={{ width: "250px" }}>
+        <Title order={2}>Notion設定</Title>
 
-          <TextInput
-            variant="filled"
-            label="NOTION_TOKEN"
-            value={apiKey || ""}
-            onChange={(e) => setApiKey(e.currentTarget.value)}
-            placeholder="NOTION_TOKEN"
-          />
-          <TextInput
-            variant="filled"
-            label="NOTION_DATABASE_ID"
-            value={databaseId || ""}
-            onChange={(e) => setDatabaseId(e.currentTarget.value)}
-            placeholder="NOTION_DATABASE_ID"
-          />
+        <TextInput
+          variant="filled"
+          label="NOTION_TOKEN"
+          value={apiKey || ""}
+          onChange={(e) => setApiKey(e.currentTarget.value)}
+          placeholder="NOTION_TOKEN"
+          mb={20}
+        />
+        <TextInput
+          variant="filled"
+          label="NOTION_DATABASE_ID"
+          value={databaseId || ""}
+          onChange={(e) => setDatabaseId(e.currentTarget.value)}
+          placeholder="NOTION_DATABASE_ID"
+          mb={20}
+        />
+        <Center>
           <Button onClick={handleSaveConfig}>保存</Button>
-        </Container>
-      </>
+        </Center>
+      </Container>
     );
   }
 
   if (step === "search") {
     return (
-      <Container>
+      <Container style={{ width: "250px" }}>
         <Title order={2}>Error検索</Title>
+        <Button onClick={handleResetKeys}>Key-reset</Button>
+
         <Textarea
           value={inputText}
           onChange={(e) => setInputText(e.currentTarget.value)}
@@ -138,7 +145,7 @@ const App: React.FC = () => {
 
   if (step === "resolve") {
     return (
-      <Container style={containerStyles}>
+      <Container style={{ width: "250px" }}>
         <Title order={2}>Error 検索中</Title>
         {notionUrl && (
           <Button onClick={handleResolve} className="button">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from "react";
 import { createPost, updatePost } from "./notionClient";
 import {
   Container,
-  TextInput,
+  PasswordInput,
   Button,
   Title,
   LoadingOverlay,
   Textarea,
-  Center,
+  Space,
+  Flex,
+  Text,
 } from "@mantine/core";
 
 const App: React.FC = () => {
@@ -90,67 +92,104 @@ const App: React.FC = () => {
 
   if (step === "setup") {
     return (
-      <Container style={{ width: "250px" }}>
+      <Container style={{ width: "300px", height: "250px" }}>
         <Title order={2}>Notion設定</Title>
 
-        <TextInput
-          variant="filled"
+        <PasswordInput
+          variant={"filled"}
+          radius={"lg"}
           label="NOTION_TOKEN"
+          withAsterisk
           value={apiKey || ""}
           onChange={(e) => setApiKey(e.currentTarget.value)}
           placeholder="NOTION_TOKEN"
           mb={20}
         />
-        <TextInput
-          variant="filled"
+        <PasswordInput
+          variant={"filled"}
+          radius={"lg"}
           label="NOTION_DATABASE_ID"
+          withAsterisk
           value={databaseId || ""}
           onChange={(e) => setDatabaseId(e.currentTarget.value)}
           placeholder="NOTION_DATABASE_ID"
           mb={20}
         />
-        <Center>
-          <Button onClick={handleSaveConfig}>保存</Button>
-        </Center>
+        <Flex justify={"flex-end"} align={"center"} direction={"row"}>
+          <Button variant={"default"} radius={"lg"} onClick={handleSaveConfig}>
+            保存
+          </Button>
+        </Flex>
       </Container>
     );
   }
 
   if (step === "search") {
     return (
-      <Container style={{ width: "250px" }}>
-        <Title order={2}>Error検索</Title>
-        <Button onClick={handleResetKeys}>Key-reset</Button>
-
+      <Container style={{ width: "300px", height: "250px" }}>
+        <Flex
+          gap={"xl"}
+          justify={"flex-start"}
+          align={"center"}
+          direction={"row"}
+        >
+          <Title order={2}>Error検索</Title>
+          <Button
+            color={"red.6"}
+            variant={"subtle"}
+            size={"sm"}
+            onClick={handleResetKeys}
+          >
+            Key-reset
+          </Button>
+        </Flex>
+        <Space h="lg" />
         <Textarea
+          variant={"filled"}
+          size={"xl"}
+          radius={"md"}
           value={inputText}
           onChange={(e) => setInputText(e.currentTarget.value)}
           placeholder="検索キーワードを入力"
           disabled={isLoading || notionUrl !== null}
           mt="lg"
         />
+        <Space h="xl" />
         {!notionUrl && (
-          <Button
-            onClick={handleSearch}
-            disabled={isLoading || notionUrl !== null}
-            className="button"
-          >
-            {isLoading ? "検索中..." : "検索"}
-          </Button>
+          <Flex justify={"flex-end"}>
+            <Button
+              radius={"lg"}
+              onClick={handleSearch}
+              disabled={notionUrl !== null}
+              loading={isLoading}
+              loaderProps={{ type: "dots" }}
+            >
+              検索
+            </Button>
+          </Flex>
         )}
-        <LoadingOverlay visible={isLoading} />
       </Container>
     );
   }
 
   if (step === "resolve") {
     return (
-      <Container style={{ width: "250px" }}>
+      <Container style={{ width: "300px", height: "250px" }}>
+        <Space h="sm" />
         <Title order={2}>Error 検索中</Title>
+        <Space h="sm" />
+        <Text>・発生したErrorMessageの詳細</Text>
+        <Text>・Error発生時の具体的な操作や状況</Text>
+        <Text>・Errorの原因と考えられる要因</Text>
+        <Text>・Errorの解決策・実施手順</Text>
+        <Text>・参考にした資料やリンク情報</Text>
+        <Space h="sm" />
         {notionUrl && (
-          <Button onClick={handleResolve} className="button">
-            解決
-          </Button>
+          <Flex justify={"flex-end"}>
+            <Button color="red.7" radius={"lg"} onClick={handleResolve}>
+              解決
+            </Button>
+          </Flex>
         )}
       </Container>
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { MantineProvider } from "@mantine/core";
 import App from "./App.tsx";
+import "@mantine/core/styles.css";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## やったこと

- レイアウトの修正
- 各画面のサイズを固定
- Key情報の修正ボタンの実装

<br>

### なぜやるのか・背景（Optional）

- レイアウト部分の対応をしていなかったため 
- Key情報を登録した後に変更することができなかったため

<br>

## やらないこと

- 以前のレイアウトの維持

<br>

## できるようになること（ユーザ目線）

- NotionKey情報を再度入力することが出来る

<br>

## できなくなること（ユーザ目線）

- 以前のレイアウトでの利用

<br>

## 動作確認

- ローカルでの動作確認
- ビルド後の動作確認

<br>​


