### PR TITLE
.vscodeディレクトリの作成・rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,39 @@
-# Logs
-logs
-*.log
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/dist
+/dist-ssr
+
+# testing
+/coverage
+
+# production
+/build
+/package
+
+# vercel
+.vercel
+
+# next.js
+/.next/
+/out/
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# log files
 npm-debug.log*
 yarn-debug.log*
-yarn-error.log*
 pnpm-debug.log*
+yarn-error.log*
 lerna-debug.log*
-
-node_modules
-dist
-dist-ssr
 *.local
+logs
+*.log
 
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
+# misc
 .idea
 .DS_Store
 *.suo
@@ -22,3 +41,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*.pem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cSpell.words": ["Errorda", "nachi", "vercel", "notionhq"],
+  "window.title": "${dirty}${activeEditorShort}${separator}errorda2_chrome_extensions"
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Errorda2 Extension
+# errorda2_chrome_extensions
 
 このプロジェクトは、React と Vite を使用して構築された Chrome 拡張機能です。
 
-Errorda2 Extension は Error 解決のプロセスと成長過程を可視化するためのものです。 エラー文を検索する際にエラー文の保存とクローム検索を一度に行います。
+errorda2_chrome_extensions は Error 解決のプロセスと成長過程を可視化するためのものです。 エラー文を検索する際にエラー文の保存とクローム検索を一度に行います。
 
 - Error 解決に掛かった時間を記録します。
 - Error 解決直後に解決に至るまでに閲覧した URL や解決のヒントなどをメモに残すことができます。
 
 前提準備:
-- 下記のNotionTemplateの使用を前提としています。
+
+- 下記の NotionTemplate の使用を前提としています。
 - [テンプレート](https://honored-motion-55e.notion.site/129eaa80727680f19b06d02621f24066?v=129eaa807276819899ee000c30bb0f5b&pvs=4)
 
-## Chromeウェブストアでの利用
+## Chrome ウェブストアでの利用
 
 [ダウンロードリンク先](https://chromewebstore.google.com/detail/errorda2-extension/kiokhdhbecikhmpdancgmchlpjjbbkjg)
 
@@ -26,7 +27,7 @@ git clone https://github.com/yourusername/errorda2_chrome_extensions.git
 cd errorda2_chrome_extensions.git
 ```
 
-2. **Dockerで環境構築:**
+2. **Docker で環境構築:**
 
 ```sh
 cd docker-chrome

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Errorda2 Extension",
-  "version": "1.0.0",
+  "name": "Errorda2",
+  "version": "1.0.1",
+  "description": "This extension integrates with Notion to create a new page in the Notion database using the Google search keywords. It tracks the time from search initiation to resolution and records the process by navigating to the created page upon completion.",
   "permissions": ["storage"],
   "host_permissions": ["https://api.notion.com/*"],
   "action": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Errorda2",
   "version": "1.0.1",
-  "description": "This extension integrates with Notion to create a new page in the Notion database using the Google search keywords. It tracks the time from search initiation to resolution and records the process by navigating to the created page upon completion.",
+  "description": "Integrates with Notion to create pages using Google search keywords, tracks time from search to resolution, and records the process.",
   "permissions": ["storage"],
   "host_permissions": ["https://api.notion.com/*"],
   "action": {


### PR DESCRIPTION
## やったこと

- .gitignoreの記載内容修正
- .vscodeディレクトリの作成
  - スペルチェック対象外ワードの登録
  - タイトル名を設定
- 拡張機能の名前更新・説明の追記
- READMEでのプロジェクト名を変更
  <br>

## なぜやるのか・背景

- 管理対象外ファイルの見直し
- 意図しない警告マークを発生させないため・視認性向上の為
- 名前が長いと感じたため・説明欄を記載していなかったため
- [Errorda2](https://github.com/nachi739/Errorda2)との関係性を明確にするため
  <br>

## 動作確認

- OS:mac Web:chrome
- vscode上で反映されていることを確認
- ビルドを行いデベロッパーモードで読み込み反映を確認
  <br>

## Refs

- ~chromeウェブストアに申請中~
- 承認され公開されていることを確認
- https://chromewebstore.google.com/detail/errorda2/kiokhdhbecikhmpdancgmchlpjjbbkjg

## その他
- Chrome拡張機能の説明欄の上限文字は132文字
