### PR TITLE
検索時にDateカラムに日付入力

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Errorda2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Integrates with Notion to create pages using Google search keywords, tracks time from search to resolution, and records the process.",
   "permissions": ["storage"],
   "host_permissions": ["https://api.notion.com/*"],

--- a/src/notionClient.ts
+++ b/src/notionClient.ts
@@ -16,6 +16,7 @@ export const createPost = async (
 
   // 現在の日時を取得（検索開始時の時刻）
   const timestamp = dayjs.tz().format("YYYY-MM-DD HH:mm:ssZ");
+  const date = dayjs.tz().format("YYYY-MM-DD");
 
   const response = await notion.pages.create({
     parent: { database_id: databaseId },
@@ -32,6 +33,11 @@ export const createPost = async (
       "Start time": {
         date: {
           start: timestamp,
+        },
+      },
+      Date: {
+        date: {
+          start: date,
         },
       },
     },


### PR DESCRIPTION
## やったこと

- Error検索時にNotionのDateカラムにも時刻が入力されるように修正
  <br>

## なぜやるのか・背景

- 後から入力する想定で実装していなかったが入力漏れを防止するため
  <br>

## 動作確認

- OS:mac Web:Chrome
- ビルドを行いデベロッパーモードで読み込み
- Notion側で記載されていることを確認
  <br>

## Refs

- 更新に伴いストアに審査中
- version1.0.1 →1.0.2へ更新
  <br>
